### PR TITLE
AuthInput 컴포넌트 2차 수정

### DIFF
--- a/src/components/AuthInput/AuthInput.style.ts
+++ b/src/components/AuthInput/AuthInput.style.ts
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 export const Box = styled.div`
   display: flex;
@@ -26,11 +26,19 @@ export const TypeNumber = styled.input.attrs({
   border: none;
 `;
 
-export const BoxButton = styled.button`
+export const BoxButton = styled.button<{ showTimer: boolean }>`
   width: 75px;
   height: 48px;
   background-color: #3617cd;
   border-radius: 0px 4px 4px 0px;
   margin-left: 14px;
   color: white;
+
+  ${(props) =>
+    props.showTimer &&
+    css`
+      background: none;
+      border-left: 1px solid #dcdcdc;
+      color: black;
+    `}
 `;

--- a/src/components/AuthInput/AuthInput.tsx
+++ b/src/components/AuthInput/AuthInput.tsx
@@ -1,12 +1,18 @@
-import CountdownTimer from "../CountdownTimer/CountdownTimer";
+import React, { useState } from "react";
 import * as S from "./AuthInput.style";
 
-const AuthInput = () => {
+interface AuthInputProps {
+  showTimer: boolean;
+  onButtonClick: () => void;
+}
+
+const AuthInput: React.FC<AuthInputProps> = ({ showTimer, onButtonClick }) => {
   return (
     <S.Box>
       <S.TypeNumber placeholder="휴대전화 번호를 입력해주세요" />
-      <CountdownTimer showTimer />
-      <S.BoxButton type="button">인증</S.BoxButton>
+      <S.BoxButton type="button" onClick={onButtonClick} showTimer={showTimer}>
+        {showTimer ? "재발송" : "인증"}
+      </S.BoxButton>
     </S.Box>
   );
 };

--- a/src/components/AuthInputConfirm/AuthInputConfirm.style.ts
+++ b/src/components/AuthInputConfirm/AuthInputConfirm.style.ts
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 export const Box = styled.div`
   display: flex;
@@ -24,10 +24,16 @@ export const TypeNumber = styled.input.attrs({
   border: none;
 `;
 
-export const BoxButton = styled.button`
+export const BoxButton = styled.button<{ showTimer: boolean }>`
   width: 75px;
   height: 46px;
   background-color: #f0f0f0f0;
   border-radius: 0 4px 4px 0;
   color: #bcbcbc;
+  ${(props) =>
+    props.showTimer &&
+    css`
+      background-color: #3617cd;
+      color: white;
+    `}
 `;

--- a/src/components/AuthInputConfirm/AuthInputConfirm.tsx
+++ b/src/components/AuthInputConfirm/AuthInputConfirm.tsx
@@ -1,12 +1,19 @@
+import React from "react";
 import CountdownTimer from "../CountdownTimer/CountdownTimer";
 import * as S from "./AuthInputConfirm.style";
 
-const AuthInputConfirm = () => {
+interface AuthInputConfirmProps {
+  showTimer: boolean;
+}
+
+const AuthInputConfirm: React.FC<AuthInputConfirmProps> = ({ showTimer }) => {
   return (
     <S.Box>
       <S.TypeNumber placeholder="인증 번호를 입력해주세요" />
-      <CountdownTimer showTimer={false} />
-      <S.BoxButton type="button">확인</S.BoxButton>
+      {showTimer && <CountdownTimer showTimer={true} />}{" "}
+      <S.BoxButton type="button" showTimer={showTimer}>
+        확인
+      </S.BoxButton>
     </S.Box>
   );
 };

--- a/src/components/signUp/SignUp.tsx
+++ b/src/components/signUp/SignUp.tsx
@@ -7,8 +7,15 @@ import FormLayout from "../Layout/Form.layout";
 import AuthInput from "../AuthInput/AuthInput";
 import AuthInputConfirm from "../AuthInputConfirm/AuthInputConfirm";
 import TermsCheck from "../TermsCheck/TermsCheck";
+import { useState } from "react";
 
 const SignUp = () => {
+  const [showTimer, setShowTimer] = useState(false);
+
+  const handleButtonClick = () => {
+    setShowTimer(!showTimer);
+  };
+
   const {
     watch,
     reset,
@@ -112,10 +119,10 @@ const SignUp = () => {
         />
       </InputLayout>
       <InputLayout htmlFor="phone" label="휴대폰 번호" required>
-        <AuthInput />
+        <AuthInput showTimer={showTimer} onButtonClick={handleButtonClick} />
       </InputLayout>
       <InputLayout htmlFor="auth" label="인증 번호" required>
-        <AuthInputConfirm />
+        <AuthInputConfirm showTimer={showTimer} />
       </InputLayout>
       <TermsCheck />
     </FormLayout>


### PR DESCRIPTION
<img width="488" alt="스크린샷 2023-09-17 오전 7 29 08" src="https://github.com/zipkimi/front-zipkimi/assets/100990926/6258fc63-d3b0-44ce-96f5-aa13677abd3e">
<img width="491" alt="스크린샷 2023-09-17 오전 7 29 22" src="https://github.com/zipkimi/front-zipkimi/assets/100990926/95cadfd0-6196-4526-b7f7-ad5af7a906af">

피그마 디자인 시안과 일치하게 authInput 컴포넌트의 UI를 변경했습니다.